### PR TITLE
Catch HTTP 4xx and 5xx errors

### DIFF
--- a/php/KrakenAPIClient.php
+++ b/php/KrakenAPIClient.php
@@ -101,6 +101,11 @@ class KrakenAPI
         if($result===false)
             throw new KrakenAPIException('CURL error: ' . curl_error($this->curl));
 
+        // verify http code
+        $http_code = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
+        if($http_code>=400)
+            throw new KrakenAPIException('HTTP code: ' . $http_code);
+
         // decode results
         $result = json_decode($result, true);
         if(!is_array($result))
@@ -144,6 +149,11 @@ class KrakenAPI
         $result = curl_exec($this->curl);
         if($result===false)
             throw new KrakenAPIException('CURL error: ' . curl_error($this->curl));
+
+        // verify http code
+        $http_code = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
+        if($http_code>=400)
+            throw new KrakenAPIException('HTTP code: ' . $http_code);
 
         // decode results
         $result = json_decode($result, true);


### PR DESCRIPTION
This patch attepts to fix problem, when http request to kraken api gets 504 gateway timeout response. This happens from time to time, but before this patch, any HTTP 4xx/5xx error is reported as "JSON decode error" which is fairly inaccurate and hard to distinguish from actual decode errors.